### PR TITLE
Fixed display of HorizontalPager in the Interface Editor

### DIFF
--- a/res/layout/activity_tabbed_horizontal_pager_demo.xml
+++ b/res/layout/activity_tabbed_horizontal_pager_demo.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_height="fill_parent"
-    android:layout_width="fill_parent"
-    android:orientation="vertical">
+    android:layout_width="fill_parent">
     <RadioGroup
         android:id="@+id/tabs"
         android:layout_height="wrap_content"
         android:layout_width="fill_parent"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:layout_alignParentTop="true">
         <RadioButton
             android:id="@+id/radio_btn_0"
             android:layout_height="wrap_content"
@@ -32,8 +32,9 @@
     <com.github.ysamlan.horizontalpager.HorizontalPager
         android:id="@+id/horizontal_pager"
         android:layout_width="fill_parent"
-        android:layout_height="0px"
-        android:layout_weight="1">
+        android:layout_height="fill_parent"
+		android:layout_above="@+id/simple_demo_btn"
+        android:layout_below="@id/tabs">
         <ScrollView
             android:layout_width="fill_parent"
             android:layout_height="fill_parent">
@@ -73,7 +74,8 @@
     </com.github.ysamlan.horizontalpager.HorizontalPager>
     <Button
         android:id="@+id/simple_demo_btn"
+        android:layout_alignParentBottom="true"
         android:layout_height="wrap_content"
         android:layout_width="fill_parent"
         android:text="Simple Demo" />
-</LinearLayout>
+</RelativeLayout>

--- a/src/com/github/ysamlan/horizontalpager/HorizontalPager.java
+++ b/src/com/github/ysamlan/horizontalpager/HorizontalPager.java
@@ -128,8 +128,10 @@ public final class HorizontalPager extends ViewGroup {
 
         // Calculate the density-dependent snap velocity in pixels
         DisplayMetrics displayMetrics = new DisplayMetrics();
-        ((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay()
+		if (!this.isInEditMode()) {
+        	((WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay()
                 .getMetrics(displayMetrics);
+		}
         mDensityAdjustedSnapVelocity =
                 (int) (displayMetrics.density * SNAP_VELOCITY_DIP_PER_SECOND);
 


### PR DESCRIPTION
Added a View.isInEditMode() exception around the display metrics and set them to default, also updated the example layout so that the height of the View is known exactly at runtime.
